### PR TITLE
Expose HTTP response details in transport exceptions

### DIFF
--- a/jgit/src/main/java/org/openrewrite/jgit/errors/HttpResponseException.java
+++ b/jgit/src/main/java/org/openrewrite/jgit/errors/HttpResponseException.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025, Moderne Inc. and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0 which is available at
+ * https://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.openrewrite.jgit.errors;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.openrewrite.jgit.transport.URIish;
+
+/**
+ * Exception thrown when an HTTP transport operation fails with an error status.
+ * Provides access to HTTP status code, response headers, and response body
+ * for logging and analysis by consumers.
+ */
+public class HttpResponseException extends TransportException {
+	private static final long serialVersionUID = 1L;
+
+	private final int statusCode;
+	private final Map<String, List<String>> headers;
+	private final String responseBody;
+
+	/**
+	 * Constructs an HttpResponseException with full HTTP response details.
+	 *
+	 * @param uri
+	 *            URI used for transport
+	 * @param statusCode
+	 *            HTTP status code (e.g., 403, 429, 500)
+	 * @param headers
+	 *            response headers, may be null
+	 * @param responseBody
+	 *            response body content, may be null
+	 * @param message
+	 *            error message
+	 */
+	public HttpResponseException(URIish uri, int statusCode,
+			Map<String, List<String>> headers, String responseBody,
+			String message) {
+		super(uri, message);
+		this.statusCode = statusCode;
+		this.headers = headers != null ? headers : Collections.emptyMap();
+		this.responseBody = responseBody;
+	}
+
+	/**
+	 * Get the HTTP status code.
+	 *
+	 * @return HTTP status code (e.g., 403, 429, 500)
+	 */
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	/**
+	 * Get all response headers.
+	 *
+	 * @return unmodifiable map of response headers
+	 */
+	public Map<String, List<String>> getHeaders() {
+		return Collections.unmodifiableMap(headers);
+	}
+
+	/**
+	 * Get a specific header value. Header name lookup is case-insensitive.
+	 * If the header has multiple values, returns the first one.
+	 *
+	 * @param name
+	 *            header name
+	 * @return header value, or null if not present
+	 */
+	public String getHeader(String name) {
+		for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+			if (name.equalsIgnoreCase(entry.getKey())) {
+				List<String> values = entry.getValue();
+				return (values != null && !values.isEmpty()) ? values.get(0) : null;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Get the response body content.
+	 *
+	 * @return response body, or null if not available
+	 */
+	public String getResponseBody() {
+		return responseBody;
+	}
+}

--- a/jgit/src/main/java/org/openrewrite/jgit/transport/http/HttpConnection.java
+++ b/jgit/src/main/java/org/openrewrite/jgit/transport/http/HttpConnection.java
@@ -212,6 +212,16 @@ public interface HttpConnection {
 	InputStream getInputStream() throws IOException;
 
 	/**
+	 * Get error stream for reading the response body when the server returns
+	 * an error status code (4xx, 5xx). Returns null if no error occurred or
+	 * if no error data was sent by the server.
+	 *
+	 * @see HttpURLConnection#getErrorStream()
+	 * @return an input stream for reading error response data, or null
+	 */
+	InputStream getErrorStream();
+
+	/**
 	 * Get header field. According to
 	 * {@link <a href="https://tools.ietf.org/html/rfc2616#section-4.2">RFC
 	 * 2616</a>} header field names are case insensitive. Header fields defined

--- a/jgit/src/main/java/org/openrewrite/jgit/transport/http/JDKHttpConnection.java
+++ b/jgit/src/main/java/org/openrewrite/jgit/transport/http/JDKHttpConnection.java
@@ -147,6 +147,12 @@ public class JDKHttpConnection implements HttpConnection {
 
 	/** {@inheritDoc} */
 	@Override
+	public InputStream getErrorStream() {
+		return wrappedUrlConnection.getErrorStream();
+	}
+
+	/** {@inheritDoc} */
+	@Override
 	public String getHeaderField(@NonNull String name) {
 		return wrappedUrlConnection.getHeaderField(name);
 	}


### PR DESCRIPTION
## Problem

When HTTP transport operations fail (e.g., 403, 429, 5xx), JGit throws a generic `TransportException` with only a message string. The actual HTTP response details (status code, headers, body) are discarded, making it difficult for consumers to:

- Log meaningful details about failures
- Distinguish between different error types (rate limits vs permission errors)
- Implement appropriate retry logic based on server hints

## Solution

Add `HttpResponseException` extending `TransportException` that exposes:
- HTTP status code
- Response headers (with case-insensitive lookup)
- Response body

This requires adding `getErrorStream()` to the `HttpConnection` interface to read error response bodies.

Consumers can now catch `HttpResponseException` to access full response details for logging and decision-making.