### PR TITLE
Fix NPE in TemporaryBuffer when writing to closed buffer

### DIFF
--- a/jgit/src/main/java/org/openrewrite/jgit/util/TemporaryBuffer.java
+++ b/jgit/src/main/java/org/openrewrite/jgit/util/TemporaryBuffer.java
@@ -89,6 +89,10 @@ public abstract class TemporaryBuffer extends OutputStream {
 			overflow.write(b);
 			return;
 		}
+		if (blocks == null) {
+			throw new IOException(
+					"Buffer is closed and cannot accept additional data");
+		}
 
 		Block s = last();
 		if (s.isFull()) {
@@ -107,6 +111,10 @@ public abstract class TemporaryBuffer extends OutputStream {
 	@Override
 	public void write(byte[] b, int off, int len) throws IOException {
 		if (overflow == null) {
+			if (blocks == null) {
+				throw new IOException(
+						"Buffer is closed and cannot accept additional data");
+			}
 			while (len > 0) {
 				Block s = last();
 				if (s.isFull()) {


### PR DESCRIPTION
## Problem

Large repository operations that exceed the buffer's in-core limit can trigger a `NullPointerException` in `TemporaryBuffer.write()`:

```
java.lang.NullPointerException: Cannot invoke "java.util.ArrayList.size()" because "this.blocks" is null
    at org.openrewrite.jgit.util.TemporaryBuffer.last(TemporaryBuffer.java:352)
    at org.openrewrite.jgit.util.TemporaryBuffer.write(TemporaryBuffer.java:111)
    at org.openrewrite.jgit.transport.PacketLineOut.end(PacketLineOut.java:203)
    at org.openrewrite.jgit.transport.BasePackConnection.close(BasePackConnection.java:652)
```

This happens when:
1. Buffer exceeds in-core limit → `switchToOverflow()` sets `blocks = null`
2. Transport operation fails
3. `close()` is called, setting `overflow = null`
4. Error cleanup calls `pckOut.end()` which tries to write to the closed buffer
5. NPE when accessing `blocks.size()`

The NPE masks the original transport error because it's thrown during cleanup.

## Solution

Add defensive checks in `write()` methods to throw `IOException` instead of NPE when the buffer is in a closed state (both `blocks` and `overflow` are null).

## Why this works

The key insight is in `BasePackConnection.close()`:

```java
try {
    if (outNeedsEnd) {
        pckOut.end();  // throws IOException now, not NPE
    }
} catch (IOException err) {
    // Ignore any close errors
}
```

- **NPE** (RuntimeException): Not caught → bubbles up and masks the original error
- **IOException**: Caught and ignored → `close()` completes → original error propagates

This allows the actual transport failure to be reported instead of the cryptic NPE.