### PR TITLE
Include file path in patch apply exception messages

### DIFF
--- a/jgit/src/main/java/org/openrewrite/jgit/api/ApplyCommand.java
+++ b/jgit/src/main/java/org/openrewrite/jgit/api/ApplyCommand.java
@@ -600,7 +600,7 @@ public class ApplyCommand extends GitCommand<ApplyResult> {
 			// We assume hunks to be ordered
 			if (hh.getNewStartLine() <= lastHunkNewLine) {
 				throw new PatchApplyException(MessageFormat
-						.format(JGitText.get().patchApplyException, hh));
+						.format(JGitText.get().patchApplyErrorWithHunk, path, hh, "hunk out of sequence"));
 			}
 			lastHunkNewLine = hh.getNewStartLine();
 
@@ -622,7 +622,7 @@ public class ApplyCommand extends GitCommand<ApplyResult> {
 					break;
 				}
 				throw new PatchApplyException(MessageFormat
-						.format(JGitText.get().patchApplyException, hh));
+						.format(JGitText.get().patchApplyErrorWithHunk, path, hh, "cannot apply hunk"));
 			}
 			// Hunk lines as reported by the hunk may be off, so don't rely on
 			// them.
@@ -634,7 +634,7 @@ public class ApplyCommand extends GitCommand<ApplyResult> {
 			}
 			if (applyAt < afterLastHunk) {
 				throw new PatchApplyException(MessageFormat
-						.format(JGitText.get().patchApplyException, hh));
+						.format(JGitText.get().patchApplyErrorWithHunk, path, hh, "hunk application position overlaps with previous hunk"));
 			}
 			boolean applies = false;
 			int oldLinesInHunk = hh.getLinesContext()
@@ -673,7 +673,7 @@ public class ApplyCommand extends GitCommand<ApplyResult> {
 			}
 			if (!applies) {
 				throw new PatchApplyException(MessageFormat
-						.format(JGitText.get().patchApplyException, hh));
+						.format(JGitText.get().patchApplyErrorWithHunk, path, hh, "hunk does not apply to file content"));
 			}
 			// Hunk applies at applyAt. Apply it, and update afterLastHunk and
 			// lineNumberShift


### PR DESCRIPTION
## Summary

- Updated `PatchApplyException` messages to include the file path being patched
- Now uses the existing `patchApplyErrorWithHunk` message template instead of `patchApplyException`
- Provides better context for debugging patch application failures

## Problem

When a patch fails to apply, the error message only included the `HunkHeader` (line start/count info), but not which file was being patched. This made debugging difficult since the same hunk pattern could occur in multiple files within a patch.

**Before:**
```
Cannot apply: HunkHeader[1,5->2,6]
```

**After:**
```
Error applying patch in src/main/java/Foo.java, hunk HunkHeader[1,5->2,6]: hunk does not apply to file content
```

## Solution

Changed four exception throws in `ApplyCommand.applyText()` to use the `patchApplyErrorWithHunk` message template which accepts the file path as its first parameter:

1. **Hunk out of sequence** - When hunks are not properly ordered
2. **Cannot apply hunk** - When a hunk with newStartLine=0 can't be applied
3. **Hunk position overlaps** - When hunk application position conflicts with previous hunk
4. **Hunk does not apply** - When hunk content doesn't match file content

## Test plan

- [x] Code compiles successfully
- [x] Existing message templates already existed but were unused

- Fixes moderneinc/customer-requests#1759